### PR TITLE
fix(nx): remove deprecated 'affected.defaultBase' and move 'defaultBase' to root

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,9 +1,7 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "npmScope": "fake-social",
-  "affected": {
-    "defaultBase": "main"
-  },
+  "defaultBase": "main",
   "tasksRunnerOptions": {
     "default": {
       "runner": "@nrwl/nx-cloud",


### PR DESCRIPTION
This PR removes the deprecated `affected.defaultBase` property from `nx.json` and moves `defaultBase` to the root, resolving the deprecation warning.